### PR TITLE
Fix for buffer overflow in sendFrameHalfResolution.

### DIFF
--- a/CompositeVideo/CompositeOutput.h
+++ b/CompositeVideo/CompositeOutput.h
@@ -272,6 +272,7 @@ class CompositeOutput
     i = 0;
     fillShort(i); fillShort(i);
     sendLine(); sendLine();
+    i = 0;
     fillShort(i); fillValues(i, levelBlank, samplesLine / 2);
     sendLine();
 


### PR DESCRIPTION
Fixes https://github.com/bitluni/ESP32CompositeVideo/issues/10, https://github.com/bitluni/ESP32CompositeVideo/issues/8 and possibly https://github.com/bitluni/ESP32CompositeVideo/issues/7 as well.